### PR TITLE
Add rustfmt to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,8 @@ sudo: false
 env:
 - RUST_BACKTRACE=1
 rust:
+- stable
+- beta
 - nightly
+before_script:
+  - rustup component add rustfmt


### PR DESCRIPTION
Building schemafy needs rustfmt command.
And now we can use rustfmt with all toolchains :)